### PR TITLE
Add tests to ci.yaml file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,4 +65,4 @@ jobs:
 
       - name: End to End Test zoom
         run: |
-          docker run --rm -v $(pwd):/data contour-generator zoom --demUrl "pmtiles:///data/JAXA_2024_terrainrgb_z0-Z7_webp.pmtiles" --sourceMaxZoom 7  --encoding mapbox --outputMinZoom 5 --outputMaxZoom 6 --increment 100 --processes 4 --outputDir "./output_zoom" -v
+          docker run --rm -v $(pwd):/data contour-generator zoom --demUrl "pmtiles:///data/JAXA_2024_terrainrgb_z0-Z7_webp.pmtiles" --sourceMaxZoom 7  --encoding mapbox --outputMinZoom 4 --outputMaxZoom 5 --increment 100 --processes 4 --outputDir "./output_zoom" -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,17 +41,21 @@ jobs:
         with:
           context: .
           push: false
-          tags: wifidb/contour-generator:latest, wifidb/contour-generator:v${{ steps.version.outputs.version }}
+          load: true
+          tags: contour-generator
           platforms: linux/arm64,linux/amd64
           # experimental: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
       - name: End to End Test pyramid
         run: |
-          docker run --rm wifidb/contour-generator:latest pyramid --z 9 --x 272 --y 179 --demUrl "pmtiles://https://acalcutt.github.io/contour_generator/test_data/terrain-tiles.pmtiles" --sourceMaxZoom 12  --encoding mapbox  --increment 0  --outputDir "./output_pyramid"  --outputMaxZoom 15  -v
+          docker run --rm contour-generator:latest pyramid --z 9 --x 272 --y 179 --demUrl "pmtiles://https://acalcutt.github.io/contour_generator/test_data/terrain-tiles.pmtiles" --sourceMaxZoom 12  --encoding mapbox  --increment 0  --outputDir "./output_pyramid"  --outputMaxZoom 15  -v
+
       - name: End to End Test bbox
         run: |
-          docker run --rm wifidb/contour-generator:latest bbox --minx -73.51 --miny 41.23 --maxx -69.93 --maxy 42.88 --demUrl "https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png" --sourceMaxZoom 15 --encoding terrarium --increment 50 --outputMinZoom 5 --outputMaxZoom 10 --outputDir "./output_bbox" -v
+          docker run --rm contour-generator:latest bbox --minx -73.51 --miny 41.23 --maxx -69.93 --maxy 42.88 --demUrl "https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png" --sourceMaxZoom 15 --encoding terrarium --increment 50 --outputMinZoom 5 --outputMaxZoom 10 --outputDir "./output_bbox" -v
+
       - name: Download Test Data
         run: |
           curl -L -o JAXA_2024_terrainrgb_z0-Z7_webp.pmtiles https://github.com/acalcutt/contour_generator/releases/download/test_data/JAXA_2024_terrainrgb_z0-Z7_webp.pmtiles
@@ -59,6 +63,7 @@ jobs:
              echo "Error downloading the test data!"
              exit 1
           fi
+
       - name: End to End Test zoom
         run: |
-          docker run --rm wifidb/contour-generator:latest zoom --demUrl "pmtiles:///data/JAXA_2024_terrainrgb_z0-Z7_webp.pmtiles" --sourceMaxZoom 7  --encoding mapbox --outputMinZoom 5 --outputMaxZoom 6 --increment 100 --processes 4 --outputDir "./output_zoom" -v
+          docker run --rm -v $(pwd):/data contour-generator:latest zoom --demUrl "pmtiles:///data/JAXA_2024_terrainrgb_z0-Z7_webp.pmtiles" --sourceMaxZoom 7  --encoding mapbox --outputMinZoom 5 --outputMaxZoom 6 --increment 100 --processes 4 --outputDir "./output_zoom" -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,4 +65,4 @@ jobs:
 
       - name: End to End Test zoom
         run: |
-          docker run --rm -v $(pwd):/data contour-generator zoom --demUrl "pmtiles:///data/JAXA_2024_terrainrgb_z0-Z6_webp.pmtiles" --sourceMaxZoom 6  --encoding mapbox --outputMinZoom 4 --outputMaxZoom 5 --increment 100 --processes 4 --outputDir "./output_zoom" -v
+          docker run --rm -v $(pwd):/data contour-generator zoom --demUrl "pmtiles:///data/JAXA_2024_terrainrgb_z0-Z6_webp.pmtiles" --sourceMaxZoom 6 --encoding mapbox --outputMinZoom 5 --outputMaxZoom 6 --increment 100 --processes 4 --outputDir "./output_zoom" -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Download Test Data
         run: |
-          curl -L -o JAXA_2024_terrainrgb_z0-Z7_webp.pmtiles https://github.com/acalcutt/contour_generator/releases/download/test_data/JAXA_2024_terrainrgb_z0-Z7_webp.pmtiles
+          curl -L -o JAXA_2024_terrainrgb_z0-Z6_webp.pmtiles https://github.com/acalcutt/contour_generator/releases/download/test_data/JAXA_2024_terrainrgb_z0-Z6_webp.pmtiles
           if [[ $? -ne 0 ]]; then
              echo "Error downloading the test data!"
              exit 1
@@ -65,4 +65,4 @@ jobs:
 
       - name: End to End Test zoom
         run: |
-          docker run --rm -v $(pwd):/data contour-generator zoom --demUrl "pmtiles:///data/JAXA_2024_terrainrgb_z0-Z7_webp.pmtiles" --sourceMaxZoom 7  --encoding mapbox --outputMinZoom 5 --outputMaxZoom 6 --increment 100 --processes 4 --outputDir "./output_zoom" -v
+          docker run --rm -v $(pwd):/data contour-generator zoom --demUrl "pmtiles:///data/JAXA_2024_terrainrgb_z0-Z6_webp.pmtiles" --sourceMaxZoom 6  --encoding mapbox --outputMinZoom 4 --outputMaxZoom 5 --increment 100 --processes 4 --outputDir "./output_zoom" -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}-1
@@ -45,3 +46,9 @@ jobs:
           # experimental: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: End to End Test pyramid
+        run: |
+          docker run --rm wifidb/contour-generator:latest pyramid --z 9 --x 272 --y 179 --demUrl "pmtiles://https://acalcutt.github.io/contour_generator/test_data/terrain-tiles.pmtiles" --sourceMaxZoom 12  --encoding mapbox  --increment 0  --outputDir "./output_pyramid"  --outputMaxZoom 15  -v
+      - name: End to End Test bbox
+        run: |
+          docker run --rm wifidb/contour-generator:latest bbox --minx -73.51 --miny 41.23 --maxx -69.93 --maxy 42.88 --demUrl "https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png" --sourceMaxZoom 15 --encoding terrarium --increment 50 --outputMinZoom 5 --outputMaxZoom 10 --outputDir "./output_bbox" -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,11 @@ jobs:
 
       - name: End to End Test pyramid
         run: |
-          docker run --rm contour-generator:latest pyramid --z 9 --x 272 --y 179 --demUrl "pmtiles://https://acalcutt.github.io/contour_generator/test_data/terrain-tiles.pmtiles" --sourceMaxZoom 12  --encoding mapbox  --increment 0  --outputDir "./output_pyramid"  --outputMaxZoom 15  -v
+          docker run --rm contour-generator pyramid --z 9 --x 272 --y 179 --demUrl "pmtiles://https://acalcutt.github.io/contour_generator/test_data/terrain-tiles.pmtiles" --sourceMaxZoom 12  --encoding mapbox  --increment 0  --outputDir "./output_pyramid"  --outputMaxZoom 15  -v
 
       - name: End to End Test bbox
         run: |
-          docker run --rm contour-generator:latest bbox --minx -73.51 --miny 41.23 --maxx -69.93 --maxy 42.88 --demUrl "https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png" --sourceMaxZoom 15 --encoding terrarium --increment 50 --outputMinZoom 5 --outputMaxZoom 10 --outputDir "./output_bbox" -v
+          docker run --rm contour-generator bbox --minx -73.51 --miny 41.23 --maxx -69.93 --maxy 42.88 --demUrl "https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png" --sourceMaxZoom 15 --encoding terrarium --increment 50 --outputMinZoom 5 --outputMaxZoom 10 --outputDir "./output_bbox" -v
 
       - name: Download Test Data
         run: |
@@ -65,4 +65,4 @@ jobs:
 
       - name: End to End Test zoom
         run: |
-          docker run --rm -v $(pwd):/data contour-generator:latest zoom --demUrl "pmtiles:///data/JAXA_2024_terrainrgb_z0-Z7_webp.pmtiles" --sourceMaxZoom 7  --encoding mapbox --outputMinZoom 5 --outputMaxZoom 6 --increment 100 --processes 4 --outputDir "./output_zoom" -v
+          docker run --rm -v $(pwd):/data contour-generator zoom --demUrl "pmtiles:///data/JAXA_2024_terrainrgb_z0-Z7_webp.pmtiles" --sourceMaxZoom 7  --encoding mapbox --outputMinZoom 5 --outputMaxZoom 6 --increment 100 --processes 4 --outputDir "./output_zoom" -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,4 +61,4 @@ jobs:
           fi
       - name: End to End Test zoom
         run: |
-          docker run --rm wifidb/contour-generator:latest zoom --z 9 --x 272 --y 179 --demUrl "pmtiles:///data/JAXA_2024_terrainrgb_z0-Z7_webp.pmtiles" --sourceMaxZoom 7  --encoding mapbox --outputMinZoom 5 --outputMaxZoom 6 --increment 100 --processes 4 --outputDir "./output_zoom" -v
+          docker run --rm wifidb/contour-generator:latest zoom --demUrl "pmtiles:///data/JAXA_2024_terrainrgb_z0-Z7_webp.pmtiles" --sourceMaxZoom 7  --encoding mapbox --outputMinZoom 5 --outputMaxZoom 6 --increment 100 --processes 4 --outputDir "./output_zoom" -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,13 @@ jobs:
       - name: End to End Test bbox
         run: |
           docker run --rm wifidb/contour-generator:latest bbox --minx -73.51 --miny 41.23 --maxx -69.93 --maxy 42.88 --demUrl "https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png" --sourceMaxZoom 15 --encoding terrarium --increment 50 --outputMinZoom 5 --outputMaxZoom 10 --outputDir "./output_bbox" -v
+      - name: Download Test Data
+        run: |
+          curl -L -o JAXA_2024_terrainrgb_z0-Z7_webp.pmtiles https://github.com/acalcutt/contour_generator/releases/download/test_data/JAXA_2024_terrainrgb_z0-Z7_webp.pmtiles
+          if [[ $? -ne 0 ]]; then
+             echo "Error downloading the test data!"
+             exit 1
+          fi
+      - name: End to End Test zoom
+        run: |
+          docker run --rm wifidb/contour-generator:latest zoom --z 9 --x 272 --y 179 --demUrl "pmtiles:///data/JAXA_2024_terrainrgb_z0-Z7_webp.pmtiles" --sourceMaxZoom 7  --encoding mapbox --outputMinZoom 5 --outputMaxZoom 6 --increment 100 --processes 4 --outputDir "./output_zoom" -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,4 +65,4 @@ jobs:
 
       - name: End to End Test zoom
         run: |
-          docker run --rm -v $(pwd):/data contour-generator zoom --demUrl "pmtiles:///data/JAXA_2024_terrainrgb_z0-Z7_webp.pmtiles" --sourceMaxZoom 7  --encoding mapbox --outputMinZoom 4 --outputMaxZoom 5 --increment 100 --processes 4 --outputDir "./output_zoom" -v
+          docker run --rm -v $(pwd):/data contour-generator zoom --demUrl "pmtiles:///data/JAXA_2024_terrainrgb_z0-Z7_webp.pmtiles" --sourceMaxZoom 7  --encoding mapbox --outputMinZoom 5 --outputMaxZoom 6 --increment 100 --processes 4 --outputDir "./output_zoom" -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,7 @@ jobs:
           push: false
           load: true
           tags: contour-generator
-          platforms: linux/arm64,linux/amd64
-          # experimental: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
+          platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
This basically adds the examples written in the readme to the yaml file to allow end to end tests.
This doesn't check anything right now as I first want to see that it passes and doesn't take a long time to run.
After that we can decide how to know that it worked correctly, for example making sure the size of the generated files or the number of files or folder is as expected.
Since the `zoom` action in the readme takes a local file I was not sure how to properly test it.
But two tests are better than nothing I believe.